### PR TITLE
Mixed Contentにならないように

### DIFF
--- a/src/compass/css/honoka/_override.scss
+++ b/src/compass/css/honoka/_override.scss
@@ -1,5 +1,5 @@
 // font
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 @import "compass";
 @import "compass/css3";
@@ -33,7 +33,7 @@ a {
 				border-radius:  $border-radius-large;
 			}
 			> .dropdown-menu {
-				margin-top: -$navbar-padding-vertical/4*3;	
+				margin-top: -$navbar-padding-vertical/4*3;
 			}
 		}
 		> li:not(:last-child) {


### PR DESCRIPTION
httpsでアクセスするサイトの場合に、`@import`のurlがhttpであるため`Mixed Content`エラーが発生してしまいます。その修正です。

UmiをGithub pagesで公開しており、httpsでのみアクセスできるため発見しました。