### PR TITLE
.navbar-textが表示されないのを修正

### DIFF
--- a/src/compass/css/honoka/_variables.scss
+++ b/src/compass/css/honoka/_variables.scss
@@ -369,7 +369,7 @@ $navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
 $navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
 $navbar-collapse-max-height:       340px !default;
 
-$navbar-default-color:             #fff !default;
+$navbar-default-color:             $gray-darker !default;
 $navbar-default-bg:                #fff !default;
 $navbar-default-border:            darken($navbar-default-bg, 6.5%) !default;
 
@@ -395,7 +395,7 @@ $navbar-default-toggle-border-color:       #ddd !default;
 
 //=== Inverted navbar
 // Reset inverted navbar basics
-$navbar-inverse-color:                      $gray-darker !default;
+$navbar-inverse-color:                      #fff !default;
 $navbar-inverse-bg:                         $gray-darker !default;
 $navbar-inverse-border:                     darken($navbar-inverse-bg, 10%) !default;
 


### PR DESCRIPTION
`.navbar-text`の文字色が背景と同じ色に設定されていて、`.navbar-text`を指定した要素が見えなくなっていました。
この現象は`.navbar-default`と`.navbar-inverse`のいずれでも発生します。

このPRはそれを修正します。