### PR TITLE
Nico紹介サイトのURLを変更

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -285,12 +285,12 @@
       </div>
       <div class="col-md-6">
         <div class="thumbnail">
-          <a href="//kubosho.github.io/Nico/"><img src="//cdn.honokak.osaka/assets/img/nico.png"></a>
+          <a href="http://nico.kubosho.com/"><img src="//cdn.honokak.osaka/assets/img/nico.png"></a>
           <div class="caption text-center">
             <h4>Nico</h4>
             <p>"Nico"は"Honoka"にピンク系の配色を適応したテーマです。</p>
             <div>
-              <a href="//kubosho.github.io/Nico/" class="btn btn-primary">Nicoの特設ページ <i class="fa fa-external-link"></i></a>
+              <a href="http://nico.kubosho.com/" class="btn btn-primary">Nicoの特設ページ <i class="fa fa-external-link"></i></a>
               <a href="//github.com/kubosho/Nico" class="btn btn-default">Nico on GitHub <i class="fa fa-github-alt"></i></a>
             </div>
           </div>


### PR DESCRIPTION
今までの github.io から kubosho.com に変更しました。